### PR TITLE
Apply style from .clang-format to all files.

### DIFF
--- a/async_grpc/client.h
+++ b/async_grpc/client.h
@@ -21,13 +21,11 @@
 #include "async_grpc/retry.h"
 #include "async_grpc/rpc_handler_interface.h"
 #include "async_grpc/rpc_service_method_traits.h"
-
+#include "glog/logging.h"
 #include "grpc++/grpc++.h"
 #include "grpc++/impl/codegen/client_unary_call.h"
 #include "grpc++/impl/codegen/proto_utils.h"
 #include "grpc++/impl/codegen/sync_stream.h"
-
-#include "glog/logging.h"
 
 namespace async_grpc {
 

--- a/async_grpc/completion_queue_pool.cc
+++ b/async_grpc/completion_queue_pool.cc
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
+#include "async_grpc/completion_queue_pool.h"
+
 #include <cstdlib>
 
 #include "async_grpc/async_client.h"
-#include "async_grpc/completion_queue_pool.h"
 #include "common/make_unique.h"
 #include "glog/logging.h"
 
@@ -89,8 +90,7 @@ void CompletionQueuePool::Shutdown() {
 }
 
 CompletionQueuePool::CompletionQueuePool()
-    : number_completion_queues_(kDefaultNumberCompletionQueues) {
-}
+    : number_completion_queues_(kDefaultNumberCompletionQueues) {}
 
 CompletionQueuePool::~CompletionQueuePool() {
   LOG(INFO) << "~CompletionQueuePool";

--- a/async_grpc/completion_queue_thread.h
+++ b/async_grpc/completion_queue_thread.h
@@ -18,6 +18,7 @@
 #define CPP_GRPC_COMMON_COMPLETION_QUEUE_THREAD_H_
 
 #include <grpc++/grpc++.h>
+
 #include <memory>
 #include <thread>
 

--- a/async_grpc/opencensus_span.cc
+++ b/async_grpc/opencensus_span.cc
@@ -37,7 +37,8 @@ void OpencensusSpan::End() { span_.End(); }
 
 OpencensusSpan::OpencensusSpan(const std::string& name,
                                const OpencensusSpan* parent)
-    : span_(opencensus::trace::Span::StartSpan(name, parent ? &parent->span_: nullptr)) {}
+    : span_(opencensus::trace::Span::StartSpan(
+          name, parent ? &parent->span_ : nullptr)) {}
 
 }  // namespace async_grpc
 

--- a/async_grpc/retry.cc
+++ b/async_grpc/retry.cc
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
+#include "async_grpc/retry.h"
+
 #include <chrono>
 #include <cmath>
 #include <thread>
 
-#include "async_grpc/retry.h"
 #include "glog/logging.h"
 
 namespace async_grpc {
@@ -26,7 +27,7 @@ namespace async_grpc {
 RetryStrategy CreateRetryStrategy(RetryIndicator retry_indicator,
                                   RetryDelayCalculator retry_delay_calculator) {
   return [retry_indicator, retry_delay_calculator](
-      int failed_attempts, const ::grpc::Status& status) {
+             int failed_attempts, const ::grpc::Status& status) {
     if (!retry_indicator(failed_attempts, status)) {
       return optional<Duration>();
     }

--- a/async_grpc/retry.cc
+++ b/async_grpc/retry.cc
@@ -26,7 +26,7 @@ namespace async_grpc {
 RetryStrategy CreateRetryStrategy(RetryIndicator retry_indicator,
                                   RetryDelayCalculator retry_delay_calculator) {
   return [retry_indicator, retry_delay_calculator](
-      int failed_attempts, const ::grpc::Status &status) {
+      int failed_attempts, const ::grpc::Status& status) {
     if (!retry_indicator(failed_attempts, status)) {
       return optional<Duration>();
     }
@@ -35,19 +35,19 @@ RetryStrategy CreateRetryStrategy(RetryIndicator retry_indicator,
 }
 
 RetryIndicator CreateLimitedRetryIndicator(int max_attempts) {
-  return [max_attempts](int failed_attempts, const ::grpc::Status &status) {
+  return [max_attempts](int failed_attempts, const ::grpc::Status& status) {
     return failed_attempts < max_attempts;
   };
 }
 
 RetryIndicator CreateUnlimitedRetryIndicator() {
-  return [](int failed_attempts, const ::grpc::Status &status) { return true; };
+  return [](int failed_attempts, const ::grpc::Status& status) { return true; };
 }
 
 RetryIndicator CreateUnlimitedRetryIndicator(
-    const std::set<::grpc::StatusCode> &unrecoverable_codes) {
+    const std::set<::grpc::StatusCode>& unrecoverable_codes) {
   return
-      [unrecoverable_codes](int failed_attempts, const ::grpc::Status &status) {
+      [unrecoverable_codes](int failed_attempts, const ::grpc::Status& status) {
         return unrecoverable_codes.count(status.error_code()) <= 0;
       };
 }
@@ -81,7 +81,7 @@ RetryStrategy CreateUnlimitedConstantDelayStrategy(Duration delay) {
 }
 
 RetryStrategy CreateUnlimitedConstantDelayStrategy(
-    Duration delay, const std::set<::grpc::StatusCode> &unrecoverable_codes) {
+    Duration delay, const std::set<::grpc::StatusCode>& unrecoverable_codes) {
   return CreateRetryStrategy(CreateUnlimitedRetryIndicator(unrecoverable_codes),
                              CreateConstantDelayCalculator(delay));
 }

--- a/async_grpc/retry.h
+++ b/async_grpc/retry.h
@@ -29,9 +29,9 @@ using common::Duration;
 using common::optional;
 
 using RetryStrategy = std::function<optional<Duration>(
-    int /* failed_attempts */, const ::grpc::Status &)>;
+    int /* failed_attempts */, const ::grpc::Status&)>;
 using RetryIndicator =
-    std::function<bool(int /* failed_attempts */, const ::grpc::Status &)>;
+    std::function<bool(int /* failed_attempts */, const ::grpc::Status&)>;
 using RetryDelayCalculator = std::function<Duration(int /* failed_attempts */)>;
 
 RetryStrategy CreateRetryStrategy(RetryIndicator retry_indicator,
@@ -40,7 +40,7 @@ RetryStrategy CreateRetryStrategy(RetryIndicator retry_indicator,
 RetryIndicator CreateLimitedRetryIndicator(int max_attempts);
 RetryIndicator CreateUnlimitedRetryIndicator();
 RetryIndicator CreateUnlimitedRetryIndicator(
-    const std::set<::grpc::StatusCode> &unrecoverable_codes);
+    const std::set<::grpc::StatusCode>& unrecoverable_codes);
 RetryDelayCalculator CreateBackoffDelayCalculator(Duration min_delay,
                                                   float backoff_factor);
 RetryDelayCalculator CreateConstantDelayCalculator(Duration delay);
@@ -49,7 +49,7 @@ RetryStrategy CreateLimitedBackoffStrategy(Duration min_delay,
                                            int max_attempts);
 RetryStrategy CreateUnlimitedConstantDelayStrategy(Duration delay);
 RetryStrategy CreateUnlimitedConstantDelayStrategy(
-    Duration delay, const std::set<::grpc::StatusCode> &unrecoverable_codes);
+    Duration delay, const std::set<::grpc::StatusCode>& unrecoverable_codes);
 
 bool RetryWithStrategy(RetryStrategy retry_strategy,
                        std::function<::grpc::Status()> op,

--- a/async_grpc/rpc.cc
+++ b/async_grpc/rpc.cc
@@ -15,9 +15,9 @@
  */
 
 #include "async_grpc/rpc.h"
-#include "async_grpc/service.h"
 
 #include "async_grpc/common/make_unique.h"
+#include "async_grpc/service.h"
 #include "glog/logging.h"
 
 namespace async_grpc {

--- a/async_grpc/server.cc
+++ b/async_grpc/server.cc
@@ -46,12 +46,14 @@ void Server::Builder::SetServerAddress(const std::string& server_address) {
 }
 
 void Server::Builder::SetMaxReceiveMessageSize(int max_receive_message_size) {
-  CHECK_GT(max_receive_message_size, 0) << "max_receive_message_size must be larger than 0.";
+  CHECK_GT(max_receive_message_size, 0)
+      << "max_receive_message_size must be larger than 0.";
   options_.max_receive_message_size = max_receive_message_size;
 }
 
 void Server::Builder::SetMaxSendMessageSize(int max_send_message_size) {
-  CHECK_GT(max_send_message_size, 0) << "max_send_message_size must be larger than 0.";
+  CHECK_GT(max_send_message_size, 0)
+      << "max_send_message_size must be larger than 0.";
   options_.max_send_message_size = max_send_message_size;
 }
 
@@ -63,11 +65,10 @@ void Server::Builder::EnableTracing() {
 #endif
 }
 
-void Server::Builder::DisableTracing() {
-  options_.enable_tracing = false;
-}
+void Server::Builder::DisableTracing() { options_.enable_tracing = false; }
 
-void Server::Builder::SetTracingSamplerProbability(double tracing_sampler_probability) {
+void Server::Builder::SetTracingSamplerProbability(
+    double tracing_sampler_probability) {
   options_.tracing_sampler_probability = tracing_sampler_probability;
 }
 
@@ -75,7 +76,8 @@ void Server::Builder::SetTracingTaskName(const std::string& tracing_task_name) {
   options_.tracing_task_name = tracing_task_name;
 }
 
-void Server::Builder::SetTracingGcpProjectId(const std::string& tracing_gcp_project_id) {
+void Server::Builder::SetTracingGcpProjectId(
+    const std::string& tracing_gcp_project_id) {
   options_.tracing_gcp_project_id = tracing_gcp_project_id;
 }
 
@@ -177,7 +179,6 @@ void Server::Start() {
              options_.tracing_sampler_probability)});
   }
 #endif
-
 
   // Start the gRPC server process.
   server_ = server_builder_.BuildAndStart();

--- a/async_grpc/server.h
+++ b/async_grpc/server.h
@@ -30,7 +30,6 @@
 #include "async_grpc/rpc_handler.h"
 #include "async_grpc/rpc_service_method_traits.h"
 #include "async_grpc/service.h"
-
 #include "grpc++/grpc++.h"
 
 namespace async_grpc {

--- a/async_grpc/server.h
+++ b/async_grpc/server.h
@@ -36,7 +36,7 @@
 namespace async_grpc {
 namespace {
 
-constexpr int kDefaultMaxMessageSize = 10 * 1024 * 1024;  // 10 MB
+constexpr int kDefaultMaxMessageSize = 10 * 1024 * 1024;    // 10 MB
 constexpr double kDefaultTracingSamplerProbability = 0.01;  // 1 Percent
 
 }  // namespace

--- a/async_grpc/service.cc
+++ b/async_grpc/service.cc
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-#include "async_grpc/server.h"
-
 #include <cstdlib>
 
+#include "async_grpc/server.h"
 #include "glog/logging.h"
 #include "grpc++/impl/codegen/proto_utils.h"
 


### PR DESCRIPTION
Formatting with `git clang-format` was not consistent with some existing
code. Applied the `.clang-format` file's style to all C++ files with:
`clang-format --style=file **/*.h **/*.cc -i`